### PR TITLE
Allow non-js extensions

### DIFF
--- a/jsx.js
+++ b/jsx.js
@@ -65,7 +65,11 @@ define(['JSXTransformer'], function (JSXTransformer) {
         version: '0.1',
  
         load: function (name, parentRequire, load, config) {
-            var path = parentRequire.toUrl(/\.(js)$/.test(name) ? name : name + '.js');
+            config = config.jsx || {};
+            var ext = config.extension || 'js';
+            var regex = new RegExp("\.(" + ext + ")$");
+            var path = parentRequire.toUrl(regex.test(name) ? name : name + '.' + ext);
+
             fetchText(path, function (text) {
                 try {
                     if (-1 === text.indexOf('React.DOM')) {


### PR DESCRIPTION
This PR lets you set the extension for the path the `jsx!` filter looks for (personally, I use `.jsx`):

``` js
requirejs.config({
  // ...
  jsx: {
    extension: 'jsx'
  }
});
```
